### PR TITLE
⬆️ Updates Home Assistant requirement to 0.91.4

### DIFF
--- a/thelounge/config.json
+++ b/thelounge/config.json
@@ -15,9 +15,8 @@
   "boot": "auto",
   "hassio_api": true,
   "hassio_role": "default",
-  "homeassistant": "0.91.1",
+  "homeassistant": "0.91.4",
   "homeassistant_api": true,
-  "host_network": false,
   "ingress": true,
   "ports": {
     "80/tcp": null


### PR DESCRIPTION
# Proposed Changes

Updates minimal Home Assistants required version to 0.91.4.

This add-on uses WebSockets, 0.91.4 fixes the use of WebSockets with Ingress.

Also removed an obsolete config entry.

## Related Issues

n/a