### PR TITLE
:ambulances: Fixes path handling in certificates

### DIFF
--- a/thelounge/rootfs/etc/cont-init.d/nginx.sh
+++ b/thelounge/rootfs/etc/cont-init.d/nginx.sh
@@ -18,8 +18,8 @@ if bashio::var.has_value "${port}"; then
         keyfile=$(bashio::config 'keyfile')
 
         mv /etc/nginx/servers/direct-ssl.disabled /etc/nginx/servers/direct.conf
-        sed -i "s/%%certfile%%/${certfile}/g" /etc/nginx/servers/direct.conf
-        sed -i "s/%%keyfile%%/${keyfile}/g" /etc/nginx/servers/direct.conf
+        sed -i "s#%%certfile%%#${certfile}#g" /etc/nginx/servers/direct.conf
+        sed -i "s#%%keyfile%%#${keyfile}#g" /etc/nginx/servers/direct.conf
 
     else
         mv /etc/nginx/servers/direct.disabled /etc/nginx/servers/direct.conf


### PR DESCRIPTION
# Proposed Changes

If an SSL cert is in a subfolder, it will fail.
The regex used for replacement is using slashes, slashes break paths.

## Related Issues

n/a