### PR TITLE
Remove obsolete webui from configuration

### DIFF
--- a/thelounge/config.json
+++ b/thelounge/config.json
@@ -4,7 +4,6 @@
   "slug": "thelounge",
   "description": "A self-hosted web IRC client",
   "url": "https://github.com/hassio-addons/addon-thelounge",
-  "webui": "[PROTO:ssl]://[HOST]:[PORT:80]",
   "arch": ["aarch64", "amd64", "armhf", "armv7", "i386"],
   "hassio_api": true,
   "homeassistant": "0.91.4",


### PR DESCRIPTION
# Proposed Changes

Remove `webui` from configuration, as it is obsolete since this add-on has Ingress.
