### PR TITLE
Upgrade add-on base image to 9.1.2

### DIFF
--- a/thelounge/Dockerfile
+++ b/thelounge/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=hassioaddons/base:8.0.1
+ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64:9.1.2
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
@@ -6,11 +6,11 @@ FROM ${BUILD_FROM}
 # hadolint ignore=DL3003
 RUN \
     apk add --no-cache --virtual .build-dependencies \
-        yarn=1.22.4-r0 \
+        yarn=1.22.10-r0 \
     \
     && apk add --no-cache \
-        nginx=1.18.0-r0	\
-        nodejs=12.18.3-r0 \
+        nginx=1.18.0-r13	\
+        nodejs=14.15.4-r0 \
     \
     && yarn global add \
         modclean@3.0.0-beta.1 \

--- a/thelounge/build.json
+++ b/thelounge/build.json
@@ -1,9 +1,9 @@
 {
   "build_from": {
-    "aarch64": "hassioaddons/base-aarch64:8.0.1",
-    "amd64": "hassioaddons/base-amd64:8.0.1",
-    "armhf": "hassioaddons/base-armhf:8.0.1",
-    "armv7": "hassioaddons/base-armv7:8.0.1",
-    "i386": "hassioaddons/base-i386:8.0.1"
+    "aarch64": "ghcr.io/hassio-addons/base/aarch64:9.1.2",
+    "amd64": "ghcr.io/hassio-addons/base/amd64:9.1.2",
+    "armhf": "ghcr.io/hassio-addons/base/armhf:9.1.2",
+    "armv7": "ghcr.io/hassio-addons/base/armv7:9.1.2",
+    "i386": "ghcr.io/hassio-addons/base/i386:9.1.2"
   }
 }


### PR DESCRIPTION
# Proposed Changes

Upgrades the add-on base image to 9.1.2. This version brings in Alpine 3.13, so all base packages that come with that have been upgraded as well.
