### PR TITLE
🚑 Fix missing theme in default configuration

### DIFF
--- a/thelounge/config.json
+++ b/thelounge/config.json
@@ -19,7 +19,7 @@
     "certfile": "fullchain.pem",
     "keyfile": "privkey.pem",
     "default_theme": "default",
-    "themes": ["thelounge-theme-material"],
+    "themes": ["thelounge-theme-solarized"],
     "users": []
   },
   "schema": {


### PR DESCRIPTION
# Proposed Changes

The current default configuration theme is missing/taken offline.
This PR replaces it with an actively maintained one.
