### PR TITLE
Link `python3` to `python` for the `sqlite3` JS module build

### DIFF
--- a/thelounge/Dockerfile
+++ b/thelounge/Dockerfile
@@ -12,6 +12,8 @@ RUN \
         python3=3.10.4-r0 \
         yarn=1.22.19-r0 \
     \
+    && ln -s /usr/bin/python3 /usr/bin/python \
+    \
     && apk add --no-cache \
         icu-data-full=71.1-r2 \
         nginx=1.22.0-r1 \


### PR DESCRIPTION
Needed for `sqlite3` JS module build.

# Proposed Changes

I noticed that the search icon in the header was gone to search through past logs. I looked at the container logs, and found `[ERROR] Unable to load sqlite3 module. See https://github.com/mapbox/node-sqlite3/wiki/Binaries`. Looking at the sqlite file found at `/data/thelounge/logs`, I noticed it was last modified June 25th, which is probably before an upgrade of the add-on.

I went about logging into my host to install it myself. As it turns out, during a build of the `sqlite3` package, `node-gyp` runs into `/usr/bin/python: no such file or directory`. Note that this doesn't fail the package installation, it just doesn't create any binary for sqlite3. For some reason the builds must have just started using `/usr/bin/python` instead of `python3`.

## Related Issues

I did not file an issue because I am fixing it myself. You can replicate it by watching the `docker build` output, though.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
