### PR TITLE
Allow non-admins to access the add-on

### DIFF
--- a/thelounge/config.yaml
+++ b/thelounge/config.yaml
@@ -13,6 +13,7 @@ arch:
   - i386
 ingress: true
 ingress_stream: true
+panel_admin: false
 init: false
 panel_icon: mdi:chat
 ports:


### PR DESCRIPTION
# Proposed Changes

Allow non-admins to use the add-on via Ingress as well.
